### PR TITLE
ndmeter/sampler: use old samples

### DIFF
--- a/cmd/hydrotest/main.go
+++ b/cmd/hydrotest/main.go
@@ -16,7 +16,8 @@ import (
 	"github.com/rogpeppe/hydro/ndmetertest"
 )
 
-// bhttp put --json http://localhost:44441/ae/v 'Value:=200'
+// bhttp put http://localhost:44443/v/ap 'v==200'
+// bhttp put http://localhost:44443/delay 'delay=2'		# in seconds
 
 const portBase = 44440
 

--- a/ndmeter/sampler.go
+++ b/ndmeter/sampler.go
@@ -92,6 +92,11 @@ func (sampler *Sampler) GetAll(ctx context.Context, places ...SamplePlace) []*Sa
 			// Fill any samples with previously retrieved data when we have some.
 			sampler.mu.Lock()
 			defer sampler.mu.Unlock()
+			for i, s := range samples {
+				if s == nil {
+					samples[i] = sampler.recent[places[i].Addr]
+				}
+			}
 			return samples
 		case s := <-results:
 			samples[s.index] = s.sample


### PR DESCRIPTION
In the previous change, we'd missed the actual logic for using
old samples. Reinstate that. We really should have some unit tests here, sigh.